### PR TITLE
Change the wifi_init Doxygen comment AGAIN

### DIFF
--- a/main/wifi/wifi.h
+++ b/main/wifi/wifi.h
@@ -8,7 +8,7 @@
  * when the device connects to a network.
  * At the current moment, we only support WPA2-PSK encryption method
  *
- * @param esp_err_t(void) The callback function to be invoked once the device
+ * @param callback The callback function to be invoked once the device
  * connected to a network
  * @return Any error the WiFi driver may have encountered
  */


### PR DESCRIPTION
Here we are again at the dreaded wifi_init function Doxygen comment. James still hasn't learned to write proper formatted @param sections. So it is with this commit that I intend to restore order to the documentation.